### PR TITLE
Added a 'switch' command to just turn a plug on or off.

### DIFF
--- a/src/switch.py
+++ b/src/switch.py
@@ -43,8 +43,6 @@ def change_switch_state(switch, state):
                 OpenHEMS.showMessage(decoded)
             except OpenHEMS.OpenHEMSException as DecodeError:
                 print("Can't decode payload: " + str(DecodeError))
-        else:
-            print("No message waiting.")
     except UnexpectedError:
         print("Unexpected error: " + str(UnexpectedError))
     finally:
@@ -54,8 +52,8 @@ def change_switch_state(switch, state):
 def main():
     """Switches a plug on or off."""
     parser = argparse.ArgumentParser(description='Switches a plug on or off.')
-    parser.add_argument('--name', nargs=1, required=True,
-                        help='the name of the switch to act upon')
+    parser.add_argument('--device', nargs=1, required=True,
+                        help='the device ID (if hex, prefix with 0x) of the switch to act upon')
     parser.add_argument('--action', nargs=1, required=True,
                         choices=['on', 'off'], help='turns the switch on')
 
@@ -63,10 +61,10 @@ def main():
     state = 0
     if args.action[0] == 'on':
         state = 1
-    name = args.name[0]
-    value = int(name, base=16)
+    deviceidstring = args.device[0]
+    deviceid = int(deviceidstring, 0)
 
-    change_switch_state(value, state)
+    change_switch_state(deviceid, state)
 
 if __name__ == "__main__":
     # execute only if run as a script

--- a/src/switch.py
+++ b/src/switch.py
@@ -1,0 +1,73 @@
+import argparse
+from energenie import OpenHEMS, Devices
+from energenie import radio
+
+SWITCH_MESSAGE = {
+    "header": {
+        "mfrid":       Devices.MFRID,
+        "productid":   Devices.PRODUCTID_R1_MONITOR_AND_CONTROL,
+        "encryptPIP":  Devices.CRYPT_PIP,
+        "sensorid":    0 # FILL IN
+    },
+    "recs": [
+        {
+            "wr":      True,
+            "paramid": OpenHEMS.PARAM_SWITCH_STATE,
+            "typeid":  OpenHEMS.Value.UINT,
+            "length":  1,
+            "value":   0 # FILL IN
+        }
+    ]
+}
+
+def change_switch_state(switch, state):
+    request = OpenHEMS.alterMessage(SWITCH_MESSAGE,
+                                    header_sensorid=switch,
+                                    recs_0_value=state)
+
+    try:
+        radio.init()
+        OpenHEMS.init(Devices.CRYPT_PID)
+
+        command = OpenHEMS.encode(request)
+
+        radio.transmitter()
+        radio.transmit(command)
+
+        radio.receiver()
+        if radio.isReceiveWaiting():
+            print("Receiving response.")
+            payload = radio.receive()
+            try:
+                decoded = OpenHEMS.decode(payload)
+                OpenHEMS.showMessage(decoded)
+            except OpenHEMS.OpenHEMSException as DecodeError:
+                print("Can't decode payload: " + str(DecodeError))
+        else:
+            print("No message waiting.")
+    except UnexpectedError:
+        print("Unexpected error: " + str(UnexpectedError))
+    finally:
+        radio.finished()
+
+
+def main():
+    """Switches a plug on or off."""
+    parser = argparse.ArgumentParser(description='Switches a plug on or off.')
+    parser.add_argument('--name', nargs=1, required=True,
+                        help='the name of the switch to act upon')
+    parser.add_argument('--action', nargs=1, required=True,
+                        choices=['on', 'off'], help='turns the switch on')
+
+    args = parser.parse_args()
+    state = 0
+    if args.action[0] == 'on':
+        state = 1
+    name = args.name[0]
+    value = int(name, base=16)
+
+    change_switch_state(value, state)
+
+if __name__ == "__main__":
+    # execute only if run as a script
+    main()


### PR DESCRIPTION
Hi,

I wanted a way to turn my plug on or off, but none of the Energenie code samples worked in my situation so I was directed here.

I pulled some of the code from monitor.py into a new file and added some command-line parameter handling so that it can take a device ID and a state.

I run the command simply as:
    sudo python switch.py --name 0xABC --action on

(Where 'name' is the device ID in hex and 'action' is either 'on' or 'off'.)

I didn't try to centralise any common code between this and monitor.py. I figured you probably had a plan for this and I didn't want to interfere. It does mean there's some duplication though.

I'd expected the plug to send a response or acknowledgement of current state, but I'm not seeing one. Maybe I'm doing something wrong. I'd like it to be able to verify the command was received but I'm not sure how to do that.

This is enough to get me turning the plug on or off on a schedule. I don't know if it's of any use to you, but I figured I'd pass it along.

Many thanks,

```
Geoff
```
