### PR TITLE
Dynamic registry path lookup

### DIFF
--- a/src/energenie/__init__.py
+++ b/src/energenie/__init__.py
@@ -46,8 +46,9 @@ def init():
     registry.set_fsk_router(fsk_router)
     ##registry.set_ook_router(ook_router
 
-    if os.path.isfile(registry.DEFAULT_FILENAME):
-        registry.load_from(registry.DEFAULT_FILENAME)
+    path = os.path.join(sys.path[0], registry.DEFAULT_FILENAME)
+    if os.path.isfile(path):
+        registry.load_from(path)
         print("loaded registry from file")
         registry.list()
         fsk_router.list()


### PR DESCRIPTION
Makes the registry path dynamic so scripts can reference it from any working directory. 