### PR TITLE
Add missing import for 'sys'

### DIFF
--- a/src/energenie/__init__.py
+++ b/src/energenie/__init__.py
@@ -8,6 +8,7 @@
 
 import time
 import os
+import sys
 
 try:
     # Python 2


### PR DESCRIPTION
A [previous commit](https://github.com/whaleygeek/pyenergenie/commit/cf03070b85a8d0adf0cd632b3ca879e3ef43ea82) introduces a bug.

`NameError: name 'sys' is not defined`

I've added the import to fix this.