### PR TITLE
Enable Raspberry Pi build on platforms without bash

### DIFF
--- a/src/energenie/drv/build_rpi
+++ b/src/energenie/drv/build_rpi
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 # build file for Raspberry Pi use
 


### PR DESCRIPTION
I've recently dockerised the stuff that runs on my Pi, including this code. I was pleased to discover it works fine on the minimal Alpine docker image, but with one small exception: Alpine uses a different c lib (musl) to the standard Raspbian one (glibc) which the c code in the drv folder was presumably compiled with.

This is fine, because it can just be recompiled in Alpine against the correct library but Alpine is lacking a bash shell, which stops the build script running in the normal way without modification.

This change merely replaces the !# directive at the start of the script to start `sh` instead of `bash`, making it more widely compatible.