### PR TITLE
Python 3 and wheel building setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.idea/
+build/
+dist/
+pyenergenie.egg-info/
+venv/
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pip
+RPi.GPIO

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal=1

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,16 @@
-try: 
-    # for pip >= 10
-    from pip._internal.req import parse_requirements
-except ImportError: 
-    # for pip <= 9.0.3
-    from pip.req import parse_requirements
+import os
+
 from setuptools import setup
 
+here = lambda *a: os.path.join(os.path.dirname(__file__), *a)
+
 # read the long description
-with open('README.md', 'r') as readme_file:
+with open(here('README.md'), 'r') as readme_file:
     long_description = readme_file.read()
 
 # read the requirements.txt
-requirements = [str(r.req) for r in parse_requirements('requirements.txt', session='hack')]
+with open(here('requirements.txt'), 'r') as requirements_file:
+    requirements = [x.strip() for x in requirements_file.readlines()]
 
 setup(
     name='pyenergenie',

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,9 @@
-from pip.req import parse_requirements
+try: 
+    # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: 
+    # for pip <= 9.0.3
+    from pip.req import parse_requirements
 from setuptools import setup
 
 # read the long description

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setup(
         'Programming Language :: Python :: 3.6'
     ],
     packages=['pyenergenie', 'pyenergenie.energenie'],
-    package_dir={'pyenergenie': 'src/', 'energenie': 'src/energenie/'},
+    package_dir={
+        'pyenergenie': 'src/', 
+        'pyenergenie.energenie': 'src/energenie/'
+    },
     install_requires=requirements,
     package_data={
         'pyenergenie': [

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,34 @@
+from pip.req import parse_requirements
+from setuptools import setup
+
+# read the long description
+with open('README.md', 'r') as readme_file:
+    long_description = readme_file.read()
+
+# read the requirements.txt
+requirements = [str(r.req) for r in parse_requirements('requirements.txt', session='hack')]
+
+setup(
+    name='pyenergenie',
+    version='0.0.1',
+    description='A python interface to the Energenie line of products',
+    long_description=long_description,
+    author='whaleygeek',
+    classifiers=[
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.6'
+    ],
+    packages=['pyenergenie', 'pyenergenie.energenie'],
+    package_dir={'pyenergenie': 'src/', 'energenie': 'src/energenie/'},
+    install_requires=requirements,
+    package_data={
+        'pyenergenie': [
+            'energenie/drv/*'
+        ]
+    },
+    entry_points={
+        'console_scripts': [
+            'pyenergenie=pyenergenie.setup_tool:main'
+        ]
+    }
+)

--- a/src/Logger.py
+++ b/src/Logger.py
@@ -2,9 +2,15 @@
 #
 # A simple logger - logs to file.
 
-
-from energenie import OpenThings
 import os, time
+
+try:
+    # Python 3
+    from .energenie import OpenThings
+except ImportError:
+    # Python 2
+    from energenie import OpenThings
+
 
 LOG_FILENAME = "energenie.csv"
 HEADINGS = 'timestamp,mfrid,prodid,sensorid,flags,switch,voltage,freq,reactive,real,apparent,current,temperature'

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,15 +1,4 @@
 try:
-    # Python 2
-    import energenie
-    import cleanup_GPIO
-    import control_any_auto
-    import control_any_noreg
-    import discover_miihome
-    import Logger
-    import miihome_energy_monitor
-    import setup_tool
-    import Timer
-except ImportError:
     # Python 3
     from . import energenie
     from . import cleanup_GPIO
@@ -20,3 +9,14 @@ except ImportError:
     from . import mihome_energy_monitor
     from . import setup_tool
     from . import Timer
+except ImportError:
+    # Python 2
+    import energenie
+    import cleanup_GPIO
+    import control_any_auto
+    import control_any_noreg
+    import discover_miihome
+    import Logger
+    import miihome_energy_monitor
+    import setup_tool
+    import Timer

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,22 @@
+try:
+    # Python 2
+    import energenie
+    import cleanup_GPIO
+    import control_any_auto
+    import control_any_noreg
+    import discover_miihome
+    import Logger
+    import miihome_energy_monitor
+    import setup_tool
+    import Timer
+except ImportError:
+    # Python 3
+    from . import energenie
+    from . import cleanup_GPIO
+    from . import control_any_auto
+    from . import control_any_noreg
+    from . import discover_mihome
+    from . import Logger
+    from . import mihome_energy_monitor
+    from . import setup_tool
+    from . import Timer

--- a/src/control_any_auto.py
+++ b/src/control_any_auto.py
@@ -7,7 +7,14 @@
 # the correct names, before this will work.
 
 import time
-import energenie
+
+try:
+    # Python 3
+    from . import energenie
+except ImportError:
+    # Python 2
+    import energenie
+
 
 APP_DELAY = 1
 

--- a/src/control_any_noreg.py
+++ b/src/control_any_noreg.py
@@ -4,7 +4,14 @@
 # Shows how to address sockets directly without using the registry.
 
 import time
-import energenie
+
+try:
+    # Python 3
+    from . import energenie
+except ImportError:
+    # Python 2
+    import energenie
+
 
 APP_DELAY = 1
 

--- a/src/control_any_reg.py
+++ b/src/control_any_reg.py
@@ -7,7 +7,14 @@
 # You should first run setup_tool.py and join some sockets
 
 import time
-import energenie
+
+try:
+    # Python 3
+    from . import energenie
+except ImportError:
+    # Python 2
+    import energenie
+
 
 APP_DELAY = 2 # number of seconds to toggle the socket switches
 

--- a/src/discover_mihome.py
+++ b/src/discover_mihome.py
@@ -4,7 +4,12 @@
 # However, this is an example of how to do your own discovery using
 # one of the built in discovery design patterns.
 
-import energenie
+try:
+    # Python 3
+    from . import energenie
+except ImportError:
+    # Python 2
+    import energenie
 
 # You could also use the standard energenie.ask callback instead if you want
 # as that does exactly the same thing

--- a/src/mihome_energy_monitor.py
+++ b/src/mihome_energy_monitor.py
@@ -6,9 +6,17 @@
 # Any device that has a switch, it toggles it every 2 seconds.
 # Any device that offers a power reading, it displays it.
 
-import energenie
-import Logger
 import time
+
+try:
+    # Python 3
+    from . import energenie
+    from . import Logger
+except ImportError:
+    # Python 2
+    import energenie
+    import Logger
+
 
 APP_DELAY    = 2
 switch_state = False

--- a/src/setup_tool.py
+++ b/src/setup_tool.py
@@ -9,8 +9,13 @@
 
 
 import time
-import energenie
-##from energenie.lifecycle import *
+
+try:
+    # Python 3
+    from . import energenie
+except ImportError:
+    # Python 2
+    import energenie
 
 
 #===== GLOBALS =====

--- a/src/setup_tool.py
+++ b/src/setup_tool.py
@@ -338,13 +338,19 @@ def setup_tool():
             handle_choice(MAIN_MENU, choice)
 
 
-if __name__ == "__main__":
+def main():
+    """Main entry point"""
 
     energenie.init()
     try:
         setup_tool()
     finally:
         energenie.finished()
+
+
+if __name__ == "__main__":
+
+    main()
 
 
 # END


### PR DESCRIPTION
- Updated imports to support python 3.
- Added setup artefacts to support building a wheel (allow library to be included as a dependency in requirements.txt for virtual env deployment).