### PR TITLE
Fix undefined error in get_apparent_power for MIHO006

### DIFF
--- a/src/energenie/Devices.py
+++ b/src/energenie/Devices.py
@@ -1002,7 +1002,7 @@ class MIHO006(MiHomeDevice):
         return self.readings.current
 
     def get_apparent_power(self): # -> power:float
-        return self.reading.apparent_power
+        return self.readings.apparent_power
 
 
 


### PR DESCRIPTION
Quick fix for an error when using get_apparent_power for the MIHO006